### PR TITLE
chore(ci): camel monitor operator rename

### DIFF
--- a/docs/content/blog/2026/openshift-all-helm-chart-release.md
+++ b/docs/content/blog/2026/openshift-all-helm-chart-release.md
@@ -15,7 +15,7 @@ We're excited to announce the release of [**`camel-dashboard-openshift-all`**](h
 ## What's Included
 
 Previously, deploying Camel Dashboard required installing multiple components separately:
-- **Camel Dashboard Operator**: Manages Camel Dashboard instances
+- **Camel Monitor Operator**: Manages Camel Monitor operator instances
 - **Camel Dashboard Console**: OpenShift Console plugin for monitoring
 - **Hawtio Online Console Plugin**: Optional management console for Java applications
 

--- a/docs/content/docs/installation-guide/_index.md
+++ b/docs/content/docs/installation-guide/_index.md
@@ -6,7 +6,7 @@ weight: 20
 
 Let's install Camel Dashboard, which consists of two main components:
 
-* **Camel Dashboard Operator** - Monitors Camel applications on Kubernetes and collects metrics
+* **Camel Monitor Operator** - Monitors Camel applications on Kubernetes and collects metrics
 * **Camel Dashboard Console** - OpenShift Console plugin providing visual representation of the operator data
 
 Additionally, you can enhance your monitoring capabilities with:

--- a/docs/content/docs/installation-guide/advanced/console/_index.md
+++ b/docs/content/docs/installation-guide/advanced/console/_index.md
@@ -22,11 +22,11 @@ This operator can work standalone and you can use the data exposed in the `Camel
 
 ## Camel Dashboard Console dependencies matrix
 
-The Camel Dashboard Console is a plugin extension of OpenShift Console exposing the data from the Camel Dashboard Operator.
+The Camel Dashboard Console is a plugin extension of OpenShift Console exposing the data from the Camel Monitor Operator.
 
 Below you can find the compatibility list for its dependencies:
 
-| Camel Dashboard Console | Openshift          | Camel Dashboard Operator |
+| Camel Dashboard Console | Openshift          | Camel Monitor Operator |
 | ----------------------- | ------------------ | ------------------------ |
 | next (0.3.3)            | Openshift 4.20+    | 0.1.0                    |
 | 0.3.2                   | Openshift 4.20+    | 0.1.0                    |
@@ -47,7 +47,7 @@ The following Helm parameters are required:
 
 Additional parameters can be specified if desired. Consult the chart values file for the full set of supported parameters.
 
-First, add the chart repository to the local helm [configuration](https://helm.sh/docs/helm/helm_repo_add/) (you might have already done it if you installed the [Camel Dashboard Operator](/camel-dashboard/docs/operator)):
+First, add the chart repository to the local helm [configuration](https://helm.sh/docs/helm/helm_repo_add/) (you might have already done it if you installed the [Camel Monitor Operator](/camel-dashboard/docs/operator)):
 ```bash
 $ helm repo add camel-dashboard https://camel-tooling.github.io/camel-dashboard/charts
 ```

--- a/docs/content/docs/installation-guide/advanced/operator/_index.md
+++ b/docs/content/docs/installation-guide/advanced/operator/_index.md
@@ -1,12 +1,12 @@
 ---
-title: "Camel Dashboard Operator"
-linkTitle: "Camel Dashboard Operator"
+title: "Camel Monitor Operator"
+linkTitle: "Camel Monitor Operator"
 weight: 30
 aliases:
   - /docs/installation-guide/operator/configuration/
 ---
 
-The **Camel Dashboard Operator** is a project created to simplify the management of any Camel application on a Kubernetes cluster. The tool is in charge to **monitor any Camel application** and provide a set of basic information, useful to learn how your fleet of Camel (a caravan!?) is behaving.
+The **Camel Monitor Operator** is a project created to simplify the management of any Camel application on a Kubernetes cluster. The tool is in charge to **monitor any Camel application** and provide a set of basic information, useful to learn how your fleet of Camel (a caravan!?) is behaving.
 
 The project is designed to be as simple and low resource consumption as possible. It only collects the most important Camel application KPI in order to quickly identify what's going on across your Camel applications.
 
@@ -32,7 +32,7 @@ $ helm repo add camel-dashboard https://camel-tooling.github.io/camel-dashboard/
 ```bash
 $ helm repo list
 
-NAME    URL                                   
+NAME    URL
 camel-tooling	https://camel-tooling.github.io/camel-dashboard/charts/
 ```
 

--- a/docs/content/docs/installation-guide/intallation/_index.md
+++ b/docs/content/docs/installation-guide/intallation/_index.md
@@ -12,7 +12,7 @@ aliases:
 
 A [Helm](https://helm.sh) chart is available to deploy the full Camel Dashoard to an OpenShift environment:
 
-* Camel Dashboard Operator: Manages Camel Dashboard instances
+* Camel Monitor Operator: Manages Camel Monitor operator instances
 * Camel Dashboard Console: OpenShift Console plugin for Camel Dashboard
 * Hawtio Online Console Plugin: Management and monitoring console for Java applications
 
@@ -45,7 +45,7 @@ helm install camel-dashboard-openshift-all camel-dashboard/camel-dashboard-opens
 
 By default all component will be deployed. You can choose to not deploy one or more components. Add the following to you helm install command:
 
-* Camel Dashboard Operator: `--set camel-dashboard-operator.enabled=false`
+* Camel Monitor Operator: `--set camel-monitor-operator.enabled=false`
 * Camel Dashboard Console: `--set camel-dashboard-console.enabled=false`
 * Hawtio Online Console Plugin: `--set hawtio-online-console-plugin.enabled=false`
 

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -53,7 +53,7 @@ enableGitInfo = true
   [params.og]
     type = "website"
     site_name = "Camel Dashboard"
-  
+
   # Custom CSS for Camel branding (Docsy style)
   [params.links]
   [[params.links.user]]
@@ -61,18 +61,18 @@ enableGitInfo = true
     url = "https://github.com/camel-tooling/camel-dashboard"
     icon = "fab fa-github"
     desc = "GitHub repository"
-  
-    
+
+
   # Project information
   copyright = "Apache Software Foundation"
   privacy_policy = ""
-  
+
   # Menu and navigation
   version_menu = "Releases"
   archived_version = false
   version = "main"
   url_latest_version = ""
-  
+
   # UI configuration
   [params.ui]
     sidebar_menu_compact = true
@@ -83,15 +83,15 @@ enableGitInfo = true
     navbar_logo = true
     footer_about_enable = true
     rss_sections = ["blog"]
-    
-    
+
+
   # Links for header and footer
-    
+
   [[params.links.developer]]
-    name = "GitHub Camel Dashboard Operator"
-    url = "https://github.com/camel-tooling/camel-dashboard-operator"
+    name = "GitHub Camel Monitor Operator"
+    url = "https://github.com/camel-tooling/camel-monitor-operator"
     icon = "fab fa-github"
-    desc = "GitHub repository for Camel Dashboard Operator"
+    desc = "GitHub repository for Camel Monitor Operator"
 
   [[params.links.developer]]
     name = "GitHub Camel Dashboard Console"


### PR DESCRIPTION
Likely to merge once `camel-monitor-operator` (`0.2.0`) is released.